### PR TITLE
HBASE-29098 Remove Google Analytics from Old hbasecon.com File

### DIFF
--- a/www.hbasecon.com/index.html
+++ b/www.hbasecon.com/index.html
@@ -64,10 +64,6 @@
       
 
 <body>
-	<!-- Google Tag Manager -->
-	<noscript id="ch" class="SL_swap"><iframe src="http://www.googletagmanager.com/ns.html?id=GTM-96SB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<script id="ch2" class="SL_swap">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='http://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-96SB');</script>
-	<!-- End Google Tag Manager -->
 	<div class="event-header events">
 <div class="red ">
 <header id="home">


### PR DESCRIPTION
The HBase website has one old file (not updated in 4 years) that contains **_Google Analytics_**(GA), which causes HBase to be included on a monthly report to the Privacy Committee.

Please could you remove GA from the [/www.hbasecon.com/index.html](https://github.com/apache/hbase-site/blob/asf-site/www.hbasecon.com/index.html) file

See https://issues.apache.org/jira/browse/HBASE-29098

Thanks

Niall